### PR TITLE
[build] fix ECHO.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ nonos:
 # for A:
 #	$(TOPDIR)/build/tools/add_uhdr.sh uboot $(NONOS_B_PATH)/bin/rom.bin $(NONOS_B_PATH)/bin/rom.img arm 0x200040 0x200040
 # for B:
-	@echo "copy a926.img to rootfs/lib/firmware  "
+	@$(ECHO) "copy a926.img to rootfs/lib/firmware  "
 	@$(CP) $(NONOS_B_PATH)/bin/rom linux/rootfs/initramfs/disk/lib/firmware/a926.img 
 
 hsm_init:

--- a/Makefile.tls
+++ b/Makefile.tls
@@ -4,7 +4,7 @@ LOAD_LIMIT	= $(CPU_NUM)
 MAKE_JOBS	= -j $(JOB_LIMIT) -l $(LOAD_LIMIT)
 MAKE = make
 MAKE_ARCH	= $(MAKE) ARCH=$(ARCH)
-ECHO = echo -e
+ECHO		= /bin/echo -e
 CP = cp
 MKDIR = mkdir
 RM = rm


### PR DESCRIPTION
This patch fixes the problem where all make output produced by echo is prefixed with "-e ".

**Before:**

```bash
$ make info
-e XBOOT = q628_Rev2_EMMC_defconfig
-e UBOOT = sp7021_tppg2sunplus_defconfig
-e KERNEL = sp7021_chipC_ltpp3g2sunplus_defconfig
-e LINUX_DTB = sp7021-ltpp3g2-sunplus
-e CROSS COMPILER XBOOT = /home/ag/src/sunplus/SP7021/crossgcc/armv5-eabi--glibc--stable/bin/armv5-glibc-linux-
-e CROSS COMPILER LINUX = /home/ag/src/sunplus/SP7021/crossgcc/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-
-e CROSS COMPILER ROOTFS = /home/ag/src/sunplus/SP7021/crossgcc/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-
-e NEED ISP = 1
-e ZEBU RUN = 0
-e BOOT FROM = SDCARD
-e BOOT CHIP = C_CHIP
-e ARCH = arm
-e CHIP = Q628
-e ZMEM = 0
-e SECURE = 0
-e ENCRYPTION = 0
-e ROOTFS_CONTENT = FULL
```

**After:**

```bash
XBOOT = q628_Rev2_EMMC_defconfig
UBOOT = sp7021_tppg2sunplus_defconfig
KERNEL = sp7021_chipC_ltpp3g2sunplus_defconfig
LINUX_DTB = sp7021-ltpp3g2-sunplus
CROSS COMPILER XBOOT = /home/ag/src/sunplus/SP7021/crossgcc/armv5-eabi--glibc--stable/bin/armv5-glibc-linux-
CROSS COMPILER LINUX = /home/ag/src/sunplus/SP7021/crossgcc/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-
CROSS COMPILER ROOTFS = /home/ag/src/sunplus/SP7021/crossgcc/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-
NEED ISP = 1
ZEBU RUN = 0
BOOT FROM = SDCARD
BOOT CHIP = C_CHIP
ARCH = arm
CHIP = Q628
ZMEM = 0
SECURE = 0
ENCRYPTION = 0
ROOTFS_CONTENT = FULL
```