### PR TITLE
[build][Makefile] fix "No such file or directory" errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,8 +258,8 @@ kernel: check
 	else \
 		$(RM) -rf $(ROOTFS_DIR)/lib/modules/; \
 		$(MAKE_ARCH) $(MAKE_JOBS) -C $(LINUX_PATH) modules_install INSTALL_MOD_PATH=../../$(ROOTFS_DIR) CROSS_COMPILE=$(CROSS_COMPILE_FOR_LINUX); \
-		$(RM) $(ROOTFS_DIR)/lib/modules/$(KERNELRELEASE)/build; \
-		$(RM) $(ROOTFS_DIR)/lib/modules/$(KERNELRELEASE)/source; \
+		$(RM) -f $(ROOTFS_DIR)/lib/modules/$(KERNELRELEASE)/build; \
+		$(RM) -f $(ROOTFS_DIR)/lib/modules/$(KERNELRELEASE)/source; \
 		if [ "$(CHIP)" = "Q645" -o "$(CHIP)" = "SP7350" ]; then \
 			$(RM) -f $(LINUX_PATH)/arch/$(ARCH)/boot/$(KERNEL_ARM64_BIN); \
 			$(MAKE_ARCH) $(MAKE_JOBS) -C $(LINUX_PATH) $(KERNEL_ARM64_BIN) V=0 CROSS_COMPILE=$(CROSS_COMPILE_FOR_LINUX); \


### PR DESCRIPTION
This patch fixes warnings shown while building the Linux kernel.

**Before:**

```bash
  DEPMOD  5.10.59-SUNPLUS-v7+
make[2]: Leaving directory '/home/ag/src/sunplus/linux'
rm: cannot remove 'linux/rootfs/initramfs/disk/lib/modules/5.10.59-figcomp3-gdb771583de57-dirty/build': No such file or directory
rm: cannot remove 'linux/rootfs/initramfs/disk/lib/modules/5.10.59-figcomp3-gdb771583de57-dirty/source': No such file or directory
make[2]: Entering directory '/home/ag/src/sunplus/linux'
  CALL    scripts/atomic/check-atomics.sh
```

**After:**
```bash
  DEPMOD  5.10.59-SUNPLUS-v7+
make[2]: Leaving directory '/home/ag/src/sunplus/linux'
make[2]: Entering directory '/home/ag/src/sunplus/linux'
  CALL    scripts/atomic/check-atomics.sh
```